### PR TITLE
Various parser changes

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -2,17 +2,20 @@ module Main (main) where
 
 import Syntax.Parser
 
-import System.Environment 
+import System.IO
 
 prompt :: String -> IO String
 prompt x = do
   putStr x
+  hFlush stdout
   getLine
 
 main = do
   let processInp x = case (parseExpr x) of
-                      Right x -> do 
+                      Right x -> do
                         print x
                         main
-                      Left  e -> print e
+                      Left e -> do
+                        print e
+                        main
     in prompt "> " >>= processInp

--- a/src/Syntax/Lexer.hs
+++ b/src/Syntax/Lexer.hs
@@ -7,24 +7,24 @@ import Text.Parsec.Char
 import Text.Parsec.Combinator
 
 import Text.Parsec
-import Text.Parsec.Prim
 
 import Text.Parsec.String (Parser)
 
+languageDef :: T.LanguageDef u
 languageDef = emptyDef
   { T.commentStart    = "(*"
   , T.commentEnd      = "*)"
   , T.commentLine     = "--"
   , T.nestedComments  = True
   , T.identStart      = letter    <|> char '_'
-  , T.identLetter     = alphaNum  <|> char '_' 
+  , T.identLetter     = alphaNum  <|> char '_'
   , T.reservedNames   = names
   , T.caseSensitive   = True
   , T.reservedOpNames = ops }
-    where names = [ "true", "false" 
+    where names = [ "true", "false"
                   , "if", "then", "else"
                   , "and", "let", "rec"
-                  , "mut", "in" ] 
+                  , "mut", "in" ]
           ops = ["\\", "->"
             , "()", "?>", "="
             , "<-" ]

--- a/src/Syntax/Parser.hs
+++ b/src/Syntax/Parser.hs
@@ -150,7 +150,7 @@ declaration = build <$> commaSep1 dterm
         build tup = DTuple tup
 
 list :: Parser Expr
-list = EList <$> brackets $ semiSep1 expression
+list = EList <$> (brackets $ semiSep1 expression)
 
 assign :: Parser Expr
 assign = do
@@ -164,7 +164,7 @@ assign = do
 
 assignable :: Parser Assignable
 assignable = tupl <|> nam
-  where tupl = ATuple <$> parens $ commaSep1 assignable
+  where tupl = ATuple <$> (parens $ commaSep1 assignable)
         nam  = AName <$> identifier
 
 

--- a/src/Syntax/Parser.hs
+++ b/src/Syntax/Parser.hs
@@ -76,10 +76,10 @@ index = do e <- expression
            return $ EIndex e n
 
 tuple :: Parser Expr
-tuple = parens $ commaSep1 expression >>= \x -> return $ ETuple x
+tuple = parens $ ETuple <$> commaSep1 expression
 
 var :: Parser Expr
-var = identifier >>= \x -> return $ EVar x
+var = EVar <$> identifier
 
 if' :: Parser Expr
 if' = do reserved "if"
@@ -138,11 +138,11 @@ declaration :: Parser Declaration
 declaration = build <$> commaSep1 dterm
   where
         ddiscard = char '_' >> whiteSpace >> return DDiscard
-        dname = fmap DName identifier
+        dname = DName <$> identifier
         dparens = parens dtuple
         dterm = ddiscard <|> dname <|> dparens <?> "declaration"
         -- We don't use declaration as we allow empty tuples here
-        dtuple = fmap build (commaSep dterm)
+        dtuple = build <$> commaSep dterm
 
         build :: [Declaration] -> Declaration
         build [] = DDiscard
@@ -150,7 +150,7 @@ declaration = build <$> commaSep1 dterm
         build tup = DTuple tup
 
 list :: Parser Expr
-list = EList <$> (brackets $ semiSep1 expression)
+list = brackets $ EList <$> semiSep1 expression
 
 assign :: Parser Expr
 assign = do
@@ -163,21 +163,27 @@ assign = do
   return $ EAssign nm e1 e2
 
 assignable :: Parser Assignable
-assignable = tupl <|> nam
-  where tupl = ATuple <$> (parens $ commaSep1 assignable)
-        nam  = AName <$> identifier
-
+assignable = atuple
+  where
+        aname  = AName <$> identifier
+        aparens = parens atuple
+        aterm = aname <|> aparens
+        atuple = build <$> commaSep1 aterm
+        build :: [Assignable] -> Assignable
+        build [single] = single
+        build tup = ATuple tup
 
 term :: Parser Expr
-term = Syntax.Parser.var
-    <|> lambda
+term =
+    lambda
     <|> literal
     <|> tuple
     <|> parens term
     <|> if'
     <|> let'
     <|> list
-    <|> assign
+    <|> try assign
+    <|> Syntax.Parser.var
     <?> "expression"
 
 expression :: Parser Expr


### PR DESCRIPTION
I'm adding this as a PR as:
- Not really sure what I'm doing
- Not really sure we want this

I've made `if <cond> then <expr>` valid (as long as expr returns a unit). This only makes sense though if we allow multiple expressions in one "block" (rather than chaining expressions).
##### Various declaration changes:

Not sure about `()` being `_` or `(a)` being valid but I feel the last one is needed.

``` ocaml
(* Both compiled to discards *)
let () = 0 in 
let _ = 0 in

(* Both compiled to single variables *)
let a = 0 in
let (a) = 0 in

(* Both compiled to tuples *)
let a, b = 0 in
let (a, b) = 0 in ()
```

I've also fixed some whitespace issues (string wasn't consuming trailing whitespace).
